### PR TITLE
Add page for Sab/download clients.

### DIFF
--- a/docs/downloaders/torrent.md
+++ b/docs/downloaders/torrent.md
@@ -20,4 +20,3 @@ Find information about Torrent download clients on this page. It's a bit sparse,
 # rTorrent
 
 # uTorrent
-

--- a/docs/downloaders/torrent.md
+++ b/docs/downloaders/torrent.md
@@ -1,0 +1,23 @@
+---
+id: torrent
+title: Torrent Downloaders
+pagination_prev: unpackerr/troubleshooting
+pagination_next: downloaders/usenet
+description: Information about torrent downloaders.
+---
+
+# Torrent Downloaders
+
+Find information about Torrent download clients on this page. It's a bit sparse, so please help us
+[edit this page](https://github.com/Unpackerr/unpackerr.github.io/blob/main/docs/downloaders/torrent.md).
+
+# qBittorrent
+
+# Deluge
+
+# Transmission
+
+# rTorrent
+
+# uTorrent
+

--- a/docs/downloaders/usenet.md
+++ b/docs/downloaders/usenet.md
@@ -13,7 +13,9 @@ Find information about Usenet download clients on this page. It's a bit sparse, 
 
 # SabNZBd
 
-In the categories tab, there's a processing option - this is what causes sab to unpack the files instead of unpackerr. Select an option that isn't `default` or `+unpack`.
+In the categories tab, there's a processing option.
+This is what causes sab to unpack the files instead of unpackerr.
+Select an option that is not `default` nor `+unpack`.
 
 # NZBGet
 

--- a/docs/downloaders/usenet.md
+++ b/docs/downloaders/usenet.md
@@ -1,0 +1,32 @@
+---
+id: usenet
+title: Usenet Downloaders
+pagination_prev: downloaders/torrent
+pagination_next: introduction
+description: Information about usenet downloaders.
+---
+
+# Usenet Downloaders
+
+Find information about Usenet download clients on this page. It's a bit sparse, so please help us
+[edit this page](https://github.com/Unpackerr/unpackerr.github.io/blob/main/docs/downloaders/usenet.md).
+
+# SabNZBd
+
+In the categories tab, there's a processing option - this is what causes sab to unpack the files instead of unpackerr. Select an option that isn't `default` or `+unpack`.
+
+# NZBGet
+
+This is depressing, but...
+
+# Easynews
+
+Nothing here yet.
+
+# Newsleecher
+
+This is empty... :(
+
+# Newsbin Pro
+
+Yup, also empty.

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -17,6 +17,10 @@ to paint the full picture of how to configure Unpackerr.
 |Config Name|Variable Name|Default / Note|
 |---|---|---|
 debug|`UN_DEBUG`|`false` / Turns on more logs|
+quiet|`UN_QUIIET`|`false` / Do not print logs to stdout or stderr|
+error_stderr|`UN_ERROR_STDERR`|`false` / Print ERROR lines to stderr instead of stdout.|
+activity|`UN_ACTIVITY`|`false` / Setting true will print only queue counts with activity.|
+log_queues|`UN_LOG_QUEUES`|`1m` / Uses Go Duration. How often to print internal counters.|
 log_file|`UN_LOG_FILE`|None by default. Optionally provide a file path to write logs|
 log_files|`UN_LOG_FILES`|`10` / Log files to keep after rotating. `0` disables rotation|
 log_file_mb|`UN_LOG_FILE_MB`|`10` / Max size of log files in megabytes|
@@ -126,6 +130,7 @@ folder.delete_original|`UN_FOLDER_0_DELETE_ORIGINAL`|`false` Delete archives aft
 folder.delete_files|`UN_FOLDER_0_DELETE_FILES`|`false` Delete extracted files after successful extraction|
 folder.move_back|`UN_FOLDER_0_MOVE_BACK`|`false` Move extracted items back into original folder|
 folder.extract_isos|`UN_FOLDER_0_EXTRACT_ISOS`|`false` Setting this to true enables .iso file extraction|
+folder.disable_recursion|`UN_FOLDER_0_DISABLE_RECURSION`|`false` Setting this to true disables extracting archives inside archives|
 
 ## Command Hooks
 

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -31,7 +31,8 @@ max_retries|`UN_MAX_RETRIES`|`3` / Times to retry failed extractions. `0` = unli
 parallel|`UN_PARALLEL`|`1` / Concurrent extractions, only recommend `1`|
 file_mode|`UN_FILE_MODE`|`0644` / Extracted files are written with this mode|
 dir_mode|`UN_DIR_MODE`|`0755` / Extracted folders are written with this mode|
-passwords|`UN_PASSWORD_0`|No default; empty list. Provide a list of RAR passwords to try.
+passwords|`UN_PASSWORD_0`|No default; empty list. Provide a list of RAR passwords to try.|
+folder.interval|`UN_FOLDER_INTERVAL`|`1s` / How often poller (if enabled) checks for new folders.|
 
 Setting a log file is strongly recommend. This makes is much easier to troubleshoot problems.
 

--- a/docs/unpackerr/faq.md
+++ b/docs/unpackerr/faq.md
@@ -16,7 +16,7 @@ Great question! It has two answers.
    for you.
 1. Unpackerr can also extract files in a _watched_ (download) folder. If you download a lot of
    stuff and like it to be automatically extracted, then you can use Unpackerr for that purpose
-   as well. No Starr apps required; just something that downloads files.
+   as well. No Starr apps required; just something that downloads archives to folders.
 
 ## 1. What is a Starr app?
 

--- a/docs/unpackerr/troubleshooting.md
+++ b/docs/unpackerr/troubleshooting.md
@@ -1,8 +1,8 @@
 ---
 id: troubleshooting
-title: Tips & Tricks
+title: Troubleshooting
 pagination_prev: unpackerr/faq
-pagination_next: introduction
+pagination_next: downloaders/torrent
 description: Tips and Tricks for troubleshooting Unpackerr installations.
 ---
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -13,7 +13,7 @@ module.exports = {
       ]
     },
     'unpackerr/faq',
-    'unpackerr/troubleshooting',
+    {'Tips & Tricks': [ 'unpackerr/troubleshooting', 'downloaders/torrent', 'downloaders/usenet']},
     {
       type: 'html',
       value: '<a href="https://golift.io"><img src="https://docs.golift.io/integrations/golift.png" /></a>',


### PR DESCRIPTION
- Closes https://github.com/Unpackerr/unpackerr/issues/285
- Adds placeholder pages for Usenet and Torrent downloaders. 
- This is a place where notes and information may be added.